### PR TITLE
Use `orbit_activities` gem for Orbit HTTP calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,6 @@ gem "rake", "~> 13.0"
 
 gem "rubocop", "~> 1.7"
 
+gem "orbit_activities"
+
 gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 PATH
   remote: .
   specs:
-    linkedin_orbit (0.1.1)
+    linkedin_orbit (0.1.2)
       dotenv (~> 2.7)
       http (~> 4.4)
       json (~> 2.5)
       linkedin (~> 1.1)
+      orbit_activities (~> 0.1)
       thor (~> 1.1)
       zeitwerk (~> 2.4)
 
@@ -22,16 +23,20 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
-    ffi (1.15.0)
+    ffi (1.15.1)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -62,6 +67,11 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    orbit_activities (0.1.0)
+      http (~> 4.4)
+      json (~> 2.5)
+      rake (~> 13.0)
+      zeitwerk (~> 2.4)
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
@@ -115,6 +125,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   linkedin_orbit!
+  orbit_activities
   rake (~> 13.0)
   rspec (~> 3.4)
   rubocop (~> 1.7)

--- a/lib/linkedin_orbit.rb
+++ b/lib/linkedin_orbit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "zeitwerk"
+require "orbit_activities"
 require_relative "linkedin_orbit/version"
 
 module LinkedinOrbit

--- a/lib/linkedin_orbit/interactions/comment.rb
+++ b/lib/linkedin_orbit/interactions/comment.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "net/http"
 require "json"
 
 module LinkedinOrbit
@@ -16,22 +15,13 @@ module LinkedinOrbit
       end
 
       def after_initialize!
-        url = URI("https://app.orbit.love/api/v1/#{@orbit_workspace}/activities")
-
-        http = Net::HTTP.new(url.host, url.port)
-        http.use_ssl = true
-
-        request = Net::HTTP::Post.new(url)
-        request["Accept"] = "application/json"
-        request["Content-Type"] = "application/json"
-        request["Authorization"] = "Bearer #{@orbit_api_key}"
-        request["User-Agent"] = "community-ruby-linkedin-orbit/#{LinkedinOrbit::VERSION}"
-
-        request.body = construct_body.to_json
-
-        response = http.request(request)
-
-        JSON.parse(response.body)
+        OrbitActivities::Request.new(
+          api_key: @orbit_api_key,
+          workspace_id: @orbit_workspace,
+          user_agent: "community-ruby-linkedin-orbit/#{LinkedinOrbit::VERSION}",
+          action: "new_activity",
+          body: construct_body.to_json
+        )
       end
 
       def construct_body

--- a/lib/linkedin_orbit/version.rb
+++ b/lib/linkedin_orbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LinkedinOrbit
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end

--- a/linkedin_orbit.gemspec
+++ b/linkedin_orbit.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "~> 1.1"
   spec.add_dependency "linkedin", "~> 1.1"
   spec.add_dependency "dotenv", "~> 2.7"
+  spec.add_dependency "orbit_activities", "~> 0.1"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "webmock", "~> 3.12"
 end


### PR DESCRIPTION
Switch to using the `orbit_activities` gem instead of rolling own HTTP calls to Orbit