### PR TITLE
Introduce more error handling for no posts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    linkedin_orbit (0.1.2)
+    linkedin_orbit (0.1.3)
       dotenv (~> 2.7)
       http (~> 4.4)
       json (~> 2.5)

--- a/lib/linkedin_orbit/linkedin.rb
+++ b/lib/linkedin_orbit/linkedin.rb
@@ -12,6 +12,8 @@ module LinkedinOrbit
     def process_comments
       posts = get_posts
 
+      return posts unless posts.is_a?(Array)
+
       posts.each do |post|
         comments = get_post_comments(post["id"])
 
@@ -47,7 +49,16 @@ module LinkedinOrbit
       response = https.request(request)
 
       response = JSON.parse(response.body)
-      
+
+      return response["message"] if response["serviceErrorCode"]
+
+      if response["elements"].nil? || response["elements"].empty?
+        return <<~HEREDOC
+          No new posts to process from your LinkedIn organization.
+          If you suspect this is incorrect, verify your LinkedIn organization schema is correct in your credentials.
+        HEREDOC
+      end
+
       response["elements"].each do |element|
         posts << {
           "id" => element["activity"],

--- a/spec/linkedin_spec.rb
+++ b/spec/linkedin_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe LinkedinOrbit::Linkedin do
+  let(:subject) do
+    LinkedinOrbit::Linkedin.new(
+      linkedin_organization: "org",
+      linkedin_token: "abc123",
+      orbit_api_key: "12345",
+      orbit_workspace: "1234"
+    )
+  end
+
+  describe "#get_posts" do
+    context "with no posts to process" do
+      it "returns a string message" do
+        stub_request(:get, "https://api.linkedin.com/v2/shares?owners=org&q=owners").
+        with(
+          headers: {
+          'Accept'=>'application/json',
+          'Authorization'=>'Bearer abc123',
+          'Content-Type'=>'application/json',
+          }).
+        to_return(status: 200, body: "{\"elements\": []}", headers: {})
+
+        expect(subject.get_posts).to eql("No new posts to process from your LinkedIn organization.\nIf you suspect this is incorrect, verify your LinkedIn organization schema is correct in your credentials.\n")
+      end
+    end
+
+    context "with posts to process" do
+      it "returns them in the right formatting at the end of the method" do
+        stub_request(:get, "https://api.linkedin.com/v2/shares?owners=org&q=owners").
+        with(
+          headers: {
+          'Accept'=>'application/json',
+          'Authorization'=>'Bearer abc123',
+          'Content-Type'=>'application/json',
+          }).
+        to_return(status: 200, body: "{\"elements\": [{\"owner\": \"org\", \"activity\": \"activity-123\", \"text\": {\"text\": \"LinkedIn Post Body\"}}]}", headers: {})
+        
+        expect(subject.get_posts).to eql(
+          [
+            {
+              "id" => "activity-123",
+              "message_highlight" => "LinkedIn Post Body"
+            }
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #10 

Error reported when the LinkedIn API did not return any response data during the API call in the `#get_posts` method. 

More error handling has been introduced to account for that issue, including returning either the API error response from LinkedIn or returning a custom error message if the issue is there are no posts. This prevents the application from continuing on trying to iterate on a `nil` object. 