### PR TITLE
Convert from LinkedIn Shares to UGC Post API with updated pagination

### DIFF
--- a/lib/linkedin_orbit/interactions/comment.rb
+++ b/lib/linkedin_orbit/interactions/comment.rb
@@ -34,6 +34,7 @@ module LinkedinOrbit
             occurred_at: Time.at(@comment["created"]["time"] / 1000).utc,
             key: @comment["id"],
             link: "https://www.linkedin.com/feed/update/#{@comment["object"]}",
+            link_text: "View on LinkedIn",
             member: {
               name: name
             }

--- a/lib/linkedin_orbit/linkedin.rb
+++ b/lib/linkedin_orbit/linkedin.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require "byebug"
 module LinkedinOrbit
   class Linkedin
     def initialize(params = {})
@@ -24,7 +24,20 @@ module LinkedinOrbit
 
         next if comments.nil? || comments.empty?
 
-        comments.reject! { |comment| comment["actor~"]["id"] == "private" }
+        # Indicates that the member does not want their information shared
+        # Member viewing access if forbidden for profile memberId
+        comments.reject! do |comment| 
+          if comment.has_key? "actor!"
+              true if comment["actor!"]["status"] == 403
+          end
+        end
+
+        # Indicates that the member does not want their information shared
+        comments.reject! do |comment|
+          if comment.has_key? "actor~"
+            true if comment["actor~"]["id"] == "private"
+          end
+        end
 
         comments.each do |comment|
           unless @historical_import && orbit_timestamp

--- a/lib/linkedin_orbit/linkedin.rb
+++ b/lib/linkedin_orbit/linkedin.rb
@@ -49,7 +49,10 @@ module LinkedinOrbit
         end
       end
       
-      puts "Sent #{times} new comments to your Orbit workspace"
+      output = "Sent #{times} new comments to your Orbit workspace"
+
+      puts output
+      return output
     end
 
     def get_posts

--- a/lib/linkedin_orbit/linkedin.rb
+++ b/lib/linkedin_orbit/linkedin.rb
@@ -16,15 +16,15 @@ module LinkedinOrbit
       return posts unless posts.is_a?(Array)
 
       orbit_timestamp = last_orbit_activity_timestamp
-      
-      posts.each do |post|
-        times = 0
 
+      times = 0
+      posts.each do |post|
+    
         comments = get_post_comments(post["id"])
 
-        comments.reject! { |comment| comment["actor~"]["id"] == "private" }
-
         next if comments.nil? || comments.empty?
+
+        comments.reject! { |comment| comment["actor~"]["id"] == "private" }
 
         comments.each do |comment|
           unless @historical_import && orbit_timestamp
@@ -47,33 +47,33 @@ module LinkedinOrbit
             orbit_api_key: @orbit_api_key
           )
         end
-
-        output = "Sent #{times} new comments to your Orbit workspace"
-
-        puts output
-        return output
       end
+      
+      puts "Sent #{times} new comments to your Orbit workspace"
     end
 
     def get_posts
       posts = []
       page = 0
       count = 100
-      looped_at_least_once = false
+      total = 0
 
-      while page >= 0
-        url = URI("https://api.linkedin.com/v2/shares?q=owners&owners=#{@linkedin_organization}&start=#{page}&count=#{count}")
+      while page * count <= total
+        url = URI("https://api.linkedin.com/v2/ugcPosts?q=authors&authors=List(#{CGI.escape(@linkedin_organization)})&sortBy=LAST_MODIFIED&start=#{page*count}&count=#{count}")
         https = Net::HTTP.new(url.host, url.port)
         https.use_ssl = true
 
         request = Net::HTTP::Get.new(url)
         request["Accept"] = "application/json"
+        request["X-Restli-Protocol-Version"] = "2.0.0"
         request["Content-Type"] = "application/json"
         request["Authorization"] = "Bearer #{@linkedin_token}"
 
         response = https.request(request)
 
         response = JSON.parse(response.body)
+
+        total = response["paging"]["total"] if page == 0
 
         return response["message"] if response["serviceErrorCode"]
 
@@ -85,16 +85,13 @@ module LinkedinOrbit
         end
 
         response["elements"].each do |element|
+          next if element["id"].nil?
           posts << {
-            "id" => element["activity"],
-            "message_highlight" => element["text"]["text"][0, 40]
+            "id" => element["id"],
+            "message_highlight" => element["specificContent"]["com.linkedin.ugc.ShareContent"]["shareCommentary"]["text"][0, 40]
           }
         end
-
-        break if response["elements"].count < count
-
-        looped_at_least_once = true
-        page += 1 if looped_at_least_once
+        page += 1
       end
 
       posts

--- a/lib/linkedin_orbit/version.rb
+++ b/lib/linkedin_orbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LinkedinOrbit
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end

--- a/linkedin_orbit.gemspec
+++ b/linkedin_orbit.gemspec
@@ -5,7 +5,7 @@ require_relative "lib/linkedin_orbit/version"
 Gem::Specification.new do |spec|
   spec.name = "linkedin_orbit"
   spec.version                = LinkedinOrbit::VERSION
-  spec.authors                = ["Orbit DevRel", "Ben Greenberg"]
+  spec.authors                = ["Orbit DevRel", "Ben Greenberg", "Colin Loretz"]
   spec.email                  = ["devrel@orbit.love"]
 
   spec.summary                = "Integrate LinkedIn interactions into Orbit"

--- a/spec/interactions/comment_spec.rb
+++ b/spec/interactions/comment_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe LinkedinOrbit::Interactions::Comment do
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
             headers: { 'Authorization' => "Bearer 12345", 'Content-Type' => 'application/json' },
-            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Sample Title...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Sample Text\\\"\\n\",\"occurred_at\":\"2016-03-02 23:00:00 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/urn:li:activity:6793941564394651648\",\"member\":{\"name\":\"John Smith\"}},\"identity\":{\"source\":\"linkedin\",\"name\":\"John Smith\",\"uid\":\"1234567\"}}"
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Sample Title...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Sample Text\\\"\\n\",\"occurred_at\":\"2016-03-02 23:00:00 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/urn:li:activity:6793941564394651648\",\"link_text\":\"View on LinkedIn\",\"member\":{\"name\":\"John Smith\"}},\"identity\":{\"source\":\"linkedin\",\"name\":\"John Smith\",\"uid\":\"1234567\"}}"
           )
           .to_return(
             status: 200,

--- a/spec/linkedin_spec.rb
+++ b/spec/linkedin_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe LinkedinOrbit::Linkedin do
       it "posts the newer items to the Orbit workspace from LinkedIn" do
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
-            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"A highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"A highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"link_text\":\"View on LinkedIn\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
             headers: {
               "Accept" => "application/json",
               "Authorization" => "Bearer 12345",
@@ -86,7 +86,7 @@ RSpec.describe LinkedinOrbit::Linkedin do
 
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
-            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"link_text\":\"View on LinkedIn\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
             headers: {
               "Accept" => "application/json",
               "Authorization" => "Bearer 12345",
@@ -163,7 +163,7 @@ RSpec.describe LinkedinOrbit::Linkedin do
 
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
-            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"A highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"A highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"link_text\":\"View on LinkedIn\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
             headers: {
               "Accept" => "application/json",
               "Authorization" => "Bearer 12345",
@@ -178,7 +178,7 @@ RSpec.describe LinkedinOrbit::Linkedin do
         
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
-            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"A highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some more text\\\"\\n\",\"occurred_at\":\"2021-06-17 02:56:54 UTC\",\"key\":\"456789\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"A highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some more text\\\"\\n\",\"occurred_at\":\"2021-06-17 02:56:54 UTC\",\"key\":\"456789\",\"link\":\"https://www.linkedin.com/feed/update/\",\"link_text\":\"View on LinkedIn\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
             headers: {
               "Accept" => "application/json",
               "Authorization" => "Bearer 12345",
@@ -193,7 +193,7 @@ RSpec.describe LinkedinOrbit::Linkedin do
 
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
-            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"link_text\":\"View on LinkedIn\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
             headers: {
               "Accept" => "application/json",
               "Authorization" => "Bearer 12345",
@@ -208,7 +208,7 @@ RSpec.describe LinkedinOrbit::Linkedin do
 
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
-            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some more text\\\"\\n\",\"occurred_at\":\"2021-06-17 02:56:54 UTC\",\"key\":\"456789\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some more text\\\"\\n\",\"occurred_at\":\"2021-06-17 02:56:54 UTC\",\"key\":\"456789\",\"link\":\"https://www.linkedin.com/feed/update/\",\"link_text\":\"View on LinkedIn\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
             headers: {
               "Accept" => "application/json",
               "Authorization" => "Bearer 12345",

--- a/spec/linkedin_spec.rb
+++ b/spec/linkedin_spec.rb
@@ -84,6 +84,21 @@ RSpec.describe LinkedinOrbit::Linkedin do
             }
           }.to_json.to_s, headers: {})
 
+        stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
+          .with(
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            headers: {
+              "Accept" => "application/json",
+              "Authorization" => "Bearer 12345",
+              "Content-Type" => "application/json",
+              "User-Agent" => "community-ruby-linkedin-orbit/#{LinkedinOrbit::VERSION}"
+            }
+          ).to_return(status: 200, body: {
+            response: {
+              code: "SUCCESS"
+            }
+          }.to_json.to_s, headers: {})
+
         stub_request(:get, "https://app.orbit.love/api/v1/1234/activities?activity_type=custom:linkedin:comment&direction=DESC&items=10")
           .with(
             headers: {
@@ -160,10 +175,40 @@ RSpec.describe LinkedinOrbit::Linkedin do
               code: "SUCCESS"
             }
           }.to_json.to_s, headers: {})
-
+        
         stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
           .with(
             body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"A highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some more text\\\"\\n\",\"occurred_at\":\"2021-06-17 02:56:54 UTC\",\"key\":\"456789\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            headers: {
+              "Accept" => "application/json",
+              "Authorization" => "Bearer 12345",
+              "Content-Type" => "application/json",
+              "User-Agent" => "community-ruby-linkedin-orbit/#{LinkedinOrbit::VERSION}"
+            }
+          ).to_return(status: 200, body: {
+            response: {
+              code: "SUCCESS"
+            }
+          }.to_json.to_s, headers: {})
+
+        stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
+          .with(
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some text\\\"\\n\",\"occurred_at\":\"2021-06-28 16:43:34 UTC\",\"key\":\"12345\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
+            headers: {
+              "Accept" => "application/json",
+              "Authorization" => "Bearer 12345",
+              "Content-Type" => "application/json",
+              "User-Agent" => "community-ruby-linkedin-orbit/#{LinkedinOrbit::VERSION}"
+            }
+          ).to_return(status: 200, body: {
+            response: {
+              code: "SUCCESS"
+            }
+          }.to_json.to_s, headers: {})
+
+        stub_request(:post, "https://app.orbit.love/api/v1/1234/activities")
+          .with(
+            body: "{\"activity\":{\"activity_type\":\"linkedin:comment\",\"tags\":[\"channel:linkedin\"],\"title\":\"Commented on LinkedIn Post\",\"description\":\"LinkedIn post: \\\"Another highlight...\\\"\\n\\n\\nComment:\\n\\n\\n\\\"Some more text\\\"\\n\",\"occurred_at\":\"2021-06-17 02:56:54 UTC\",\"key\":\"456789\",\"link\":\"https://www.linkedin.com/feed/update/\",\"member\":{\"name\":\" \"}},\"identity\":{\"source\":\"linkedin\",\"name\":\" \",\"uid\":null}}",
             headers: {
               "Accept" => "application/json",
               "Authorization" => "Bearer 12345",
@@ -224,7 +269,7 @@ RSpec.describe LinkedinOrbit::Linkedin do
         allow(client).to receive(:get_posts).and_return(posts_stub)
         allow(client).to receive(:get_post_comments).and_return(comments_stub)
 
-        expect(client.process_comments).to eql("Sent 2 new comments to your Orbit workspace")
+        expect(client.process_comments).to eql("Sent 4 new comments to your Orbit workspace")
       end
     end
   end
@@ -232,15 +277,19 @@ RSpec.describe LinkedinOrbit::Linkedin do
   describe "#get_posts" do
     context "with no posts to process" do
       it "returns a string message" do
-        stub_request(:get, "https://api.linkedin.com/v2/shares?count=100&owners=org&q=owners&start=0")
+        stub_request(:get, "https://api.linkedin.com/v2/ugcPosts?authors=List(org)&count=100&q=authors&sortBy=LAST_MODIFIED&start=0")
           .with(
             headers: {
-              "Accept" => "application/json",
-              "Authorization" => "Bearer abc123",
-              "Content-Type" => "application/json"
+              'Accept'=>'application/json',
+              'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization'=>'Bearer abc123',
+              'Content-Type'=>'application/json',
+              'Host'=>'api.linkedin.com',
+              'User-Agent'=>'Ruby',
+              'X-Restli-Protocol-Version'=>'2.0.0'
             }
           )
-          .to_return(status: 200, body: "{\"elements\": []}", headers: {})
+          .to_return(status: 200, body: "{\"paging\":{\"start\":0,\"count\":100,\"links\":[{\"type\":\"application/json\",\"rel\":\"prev\",\"href\":\"/v2/ugcPosts?q=authors&start=0&count=100&sortBy=LAST_MODIFIED&authors=List(org)\"}],\"total\":0},\"elements\": []}", headers: {})
 
         expect(subject.get_posts).to eql("No new posts to process from your LinkedIn organization.\nIf you suspect this is incorrect, verify your LinkedIn organization schema is correct in your credentials.\n")
       end
@@ -248,15 +297,19 @@ RSpec.describe LinkedinOrbit::Linkedin do
 
     context "with posts to process" do
       it "returns them in the right formatting at the end of the method" do
-        stub_request(:get, "https://api.linkedin.com/v2/shares?count=100&owners=org&q=owners&start=0")
+        stub_request(:get, "https://api.linkedin.com/v2/ugcPosts?authors=List(org)&count=100&q=authors&sortBy=LAST_MODIFIED&start=0")
           .with(
             headers: {
-              "Accept" => "application/json",
-              "Authorization" => "Bearer abc123",
-              "Content-Type" => "application/json"
+              'Accept'=>'application/json',
+              'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization'=>'Bearer abc123',
+              'Content-Type'=>'application/json',
+              'Host'=>'api.linkedin.com',
+              'User-Agent'=>'Ruby',
+              'X-Restli-Protocol-Version'=>'2.0.0'
             }
           )
-          .to_return(status: 200, body: "{\"elements\": [{\"owner\": \"org\", \"activity\": \"activity-123\", \"text\": {\"text\": \"LinkedIn Post Body\"}}]}", headers: {})
+          .to_return(status: 200, body: "{\"paging\":{\"start\":0,\"count\":100,\"links\":[{\"type\":\"application/json\",\"rel\":\"prev\",\"href\":\"/v2/ugcPosts?q=authors&start=0&count=100&sortBy=LAST_MODIFIED&authors=List(org)\"}],\"total\":1},\"elements\": [{\"owner\": \"org\", \"id\": \"activity-123\", \"specificContent\": { \"com.linkedin.ugc.ShareContent\" : { \"shareCommentary\" : {\"text\": \"LinkedIn Post Body\"}}}}]}", headers: {})
 
         expect(subject.get_posts).to eql(
           [


### PR DESCRIPTION
The LinkedIn [Share API](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/share-api?tabs=http) does not work as expected as returns improper pagination and an incomplete set of data. This PR moves the integration to using the [UGC Post API](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/ugc-post-api?tabs=http).

LinkedIn reports the following, however when comparing the two APIs, we get a full dataset with the UGC API and not with the Share API:

> UGC Post is a content API best suited for creating and retrieving posts for organic video posts and video ads. For other media types, it is advised to use the Shares API.

- [x] Move to UGC API endpoint
- [x] Fix pagination
- [x] Update tests